### PR TITLE
Add support for cleaning output directory before generating new files

### DIFF
--- a/doc/todo.md
+++ b/doc/todo.md
@@ -5,7 +5,4 @@ Tasks to be done
 * Document the names of different parts of the UI to make it easier to refer to
 * Create console application
 * Investigate if e2e tests can be implements
-
-UI
-* Grid "split" should be adjustable
-* Markdon preview
+* Clean existing option should be saved for user

--- a/src/Desktop/Services/FileService.cs
+++ b/src/Desktop/Services/FileService.cs
@@ -350,6 +350,67 @@ public class FileService(ILogger<FileService> logger, IOptions<ApplicationOption
         }
     }
 
+    public async Task<bool> DeleteFolderContentsAsync(string folderPath)
+    {
+        if (string.IsNullOrWhiteSpace(folderPath))
+        {
+            logger.LogWarning("Folder path is null or empty");
+            return false;
+        }
+
+        if (!IsValidFolder(folderPath))
+        {
+            logger.LogWarning("Folder does not exist or is not accessible: {FolderPath}", folderPath);
+            return false;
+        }
+
+        try
+        {
+            logger.LogInformation("Deleting contents of folder: {FolderPath}", folderPath);
+            
+            await Task.Run(() =>
+            {
+                var directoryInfo = new DirectoryInfo(folderPath);
+                
+                // Delete all files
+                foreach (var file in directoryInfo.GetFiles())
+                {
+                    try
+                    {
+                        file.Delete();
+                        logger.LogDebug("Deleted file: {FilePath}", file.FullName);
+                    }
+                    catch (Exception ex)
+                    {
+                        logger.LogWarning(ex, "Failed to delete file: {FilePath}", file.FullName);
+                    }
+                }
+                
+                // Delete all subdirectories
+                foreach (var directory in directoryInfo.GetDirectories())
+                {
+                    try
+                    {
+                        directory.Delete(true);
+                        logger.LogDebug("Deleted directory: {DirectoryPath}", directory.FullName);
+                    }
+                    catch (Exception ex)
+                    {
+                        logger.LogWarning(ex, "Failed to delete directory: {DirectoryPath}", directory.FullName);
+                    }
+                }
+            });
+
+            logger.LogInformation("Successfully deleted contents of folder: {FolderPath}", folderPath);
+            return true;
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Error deleting folder contents: {FolderPath}", folderPath);
+            return false;
+        }
+    }
+
     public void Dispose()
     {
         if (!_disposed)

--- a/src/Desktop/Services/FileService.cs
+++ b/src/Desktop/Services/FileService.cs
@@ -377,7 +377,7 @@ public class FileService(ILogger<FileService> logger, IOptions<ApplicationOption
         // If the folder genuinely doesn’t exist, treat it as “already clean”
         if (!Directory.Exists(fullPath))
         {
-            logger.LogInformation(
+            logger.LogDebug(
                 "Folder does not exist; treating as already clean: {FolderPath}",
                 folderPath);
             return true;

--- a/src/Desktop/Services/FileService.cs
+++ b/src/Desktop/Services/FileService.cs
@@ -364,8 +364,8 @@ public class FileService(ILogger<FileService> logger, IOptions<ApplicationOption
 
         // Refuse to operate on a drive or filesystem root
         if (string.Equals(
-                fullPath.TrimEnd(Path.DirectorySeparatorChar),
-                rootPath?.TrimEnd(Path.DirectorySeparatorChar),
+                Path.TrimEndingDirectorySeparator(fullPath),
+                Path.TrimEndingDirectorySeparator(rootPath ?? string.Empty),
                 StringComparison.OrdinalIgnoreCase))
         {
             logger.LogError(
@@ -386,11 +386,11 @@ public class FileService(ILogger<FileService> logger, IOptions<ApplicationOption
         try
         {
             logger.LogInformation("Deleting contents of folder: {FolderPath}", folderPath);
-            
+
             await Task.Run(() =>
             {
                 var directoryInfo = new DirectoryInfo(folderPath);
-                
+
                 // Delete all files
                 foreach (var file in directoryInfo.GetFiles())
                 {
@@ -404,7 +404,7 @@ public class FileService(ILogger<FileService> logger, IOptions<ApplicationOption
                         logger.LogWarning(ex, "Failed to delete file: {FilePath}", file.FullName);
                     }
                 }
-                
+
                 // Delete all subdirectories
                 foreach (var directory in directoryInfo.GetDirectories())
                 {

--- a/src/Desktop/Services/IFileService.cs
+++ b/src/Desktop/Services/IFileService.cs
@@ -84,4 +84,11 @@ public interface IFileService
     /// <param name="isDirectory">Whether the path represents a directory</param>
     /// <returns>FileSystemItem with populated metadata, or null if path is invalid</returns>
     FileSystemItem? CreateFileSystemItem(string itemPath, bool isDirectory);
+
+    /// <summary>
+    /// Deletes all files and subdirectories within the specified folder
+    /// </summary>
+    /// <param name="folderPath">Path to the folder whose contents should be deleted</param>
+    /// <returns>True if successful, false otherwise</returns>
+    Task<bool> DeleteFolderContentsAsync(string folderPath);
 }

--- a/src/Desktop/ViewModels/BuildConfirmationDialogViewModel.cs
+++ b/src/Desktop/ViewModels/BuildConfirmationDialogViewModel.cs
@@ -145,7 +145,6 @@ public class BuildConfirmationDialogViewModel : ViewModelBase
 
         await Task.Run(() =>
         {
-            // Use the new ValidateAll method for better efficiency
             combinedValidationResult = _combinationService.Validate(templateFiles, sourceFiles);
 
             // Create error list for build failure checking
@@ -153,7 +152,7 @@ public class BuildConfirmationDialogViewModel : ViewModelBase
             {
                 var errorMessage = $"{error.LineNumber} - {error.Message}";
                 validationErrors.Add(errorMessage);
-                _logger.LogError("Validation error: {ErrorMessage}", error.Message);
+                _logger.LogError("Validation error: {ErrorMessage}", errorMessage);
             }
 
             foreach (var warning in combinedValidationResult.Warnings)

--- a/src/Desktop/Views/BuildConfirmationDialog.axaml
+++ b/src/Desktop/Views/BuildConfirmationDialog.axaml
@@ -48,7 +48,7 @@
             </Border>
             
             <CheckBox Content="Clean old files before build"
-                      IsChecked="{Binding CleanOld}"
+                      IsChecked="{Binding CleanOld, Mode=TwoWay}"
                       Margin="0,5,0,0" />
         </StackPanel>
 

--- a/src/Desktop/Views/BuildConfirmationDialog.axaml
+++ b/src/Desktop/Views/BuildConfirmationDialog.axaml
@@ -33,19 +33,24 @@
                    FontWeight="SemiBold" 
                    Margin="0,0,0,10" />
 
-        <!-- Output location path -->
-        <Border Grid.Row="2" 
-                Background="#F5F5F5" 
-                BorderBrush="#CCCCCC" 
-                BorderThickness="1" 
-                CornerRadius="4" 
-                Padding="10" 
-                Margin="0,0,0,20">
-            <TextBlock Text="{Binding OutputLocation}" 
-                       FontFamily="Consolas, 'Courier New', monospace" 
-                       TextWrapping="Wrap" 
-                       VerticalAlignment="Center" />
-        </Border>
+        <!-- Output location path and options -->
+        <StackPanel Grid.Row="2" Margin="0,0,0,20">
+            <Border Background="#F5F5F5" 
+                    BorderBrush="#CCCCCC" 
+                    BorderThickness="1" 
+                    CornerRadius="4" 
+                    Padding="10" 
+                    Margin="0,0,0,10">
+                <TextBlock Text="{Binding OutputLocation}" 
+                           FontFamily="Consolas, 'Courier New', monospace" 
+                           TextWrapping="Wrap" 
+                           VerticalAlignment="Center" />
+            </Border>
+            
+            <CheckBox Content="Clean old files before build"
+                      IsChecked="{Binding CleanOld}"
+                      Margin="0,5,0,0" />
+        </StackPanel>
 
         <!-- Buttons -->
         <StackPanel Grid.Row="3" 

--- a/test/Desktop.UITests/MenuAndCommandTests.cs
+++ b/test/Desktop.UITests/MenuAndCommandTests.cs
@@ -26,7 +26,7 @@ public class MenuAndCommandTests : MainWindowTestBase
         Assert.That(viewModel!.ExitCommand, Is.Not.Null, "ExitCommand should exist");
 
         // Track if exit was requested
-        bool exitRequested = false;
+        var exitRequested = false;
         viewModel.ExitRequested += (sender, e) => exitRequested = true;
 
         // Execute the exit command
@@ -42,10 +42,14 @@ public class MenuAndCommandTests : MainWindowTestBase
         window.Show();
 
         var viewModel = window.DataContext as MainWindowViewModel;
-        Assert.That(viewModel, Is.Not.Null, "ViewModel should exist");
 
-        // Verify window is initially open
-        Assert.That(window.IsVisible, Is.True, "Window should be visible initially");
+        Assert.Multiple(() =>
+        {
+            Assert.That(viewModel, Is.Not.Null, "ViewModel should exist");
+
+            // Verify window is initially open
+            Assert.That(window.IsVisible, Is.True, "Window should be visible initially");
+        });
 
         // Trigger exit through the command (this will invoke the exit event)
         viewModel!.ExitCommand.Execute(null);
@@ -74,11 +78,11 @@ public class MenuAndCommandTests : MainWindowTestBase
         Assert.That(viewModel!.ExitCommand, Is.Not.Null, "ExitCommand should be available for menu binding");
 
         // Test that the command can be executed
-        bool canExecute = viewModel.ExitCommand.CanExecute(null);
+        var canExecute = viewModel.ExitCommand.CanExecute(null);
         Assert.That(canExecute, Is.True, "ExitCommand should be executable");
 
         // Track if exit was requested
-        bool exitRequested = false;
+        var exitRequested = false;
         viewModel.ExitRequested += (sender, e) => exitRequested = true;
 
         // Execute the command (simulating menu click)
@@ -97,7 +101,7 @@ public class MenuAndCommandTests : MainWindowTestBase
         Assert.That(viewModel!.EditorContent.BuildDocumentationCommand, Is.Not.Null, "BuildDocumentationCommand should exist");
 
         // Test that the command exists and is enabled
-        bool canExecute = viewModel.EditorContent.BuildDocumentationCommand.CanExecute(null);
+        var canExecute = viewModel.EditorContent.BuildDocumentationCommand.CanExecute(null);
         Assert.That(canExecute, Is.True, "BuildDocumentationCommand should be enabled");
     }
 
@@ -108,19 +112,23 @@ public class MenuAndCommandTests : MainWindowTestBase
         window.Show();
 
         var viewModel = window.DataContext as MainWindowViewModel;
-        Assert.That(viewModel, Is.Not.Null, "ViewModel should exist");
 
         // Find the main menu and verify it has Build menu
         var menu = window.FindControl<Menu>("MainMenu");
-        Assert.That(menu, Is.Not.Null, "Main menu should exist");
-        Assert.That(menu.Items.Count, Is.EqualTo(3), "Menu should have File, View, and Build menus");
 
-        // Test that the BuildDocumentationCommand exists and is bound to the Build menu item
-        Assert.That(viewModel!.EditorContent.BuildDocumentationCommand, Is.Not.Null, "BuildDocumentationCommand should be available for menu binding");
+        Assert.Multiple(() =>
+        {
+            Assert.That(viewModel, Is.Not.Null, "ViewModel should exist");
+            Assert.That(menu, Is.Not.Null, "Main menu should exist");
+            Assert.That(menu?.Items, Has.Count.EqualTo(3), "Menu should have File, View, and Build menus");
 
-        // Test that the command is enabled
-        bool canExecute = viewModel.EditorContent.BuildDocumentationCommand.CanExecute(null);
-        Assert.That(canExecute, Is.True, "BuildDocumentationCommand should be enabled");
+            // Test that the BuildDocumentationCommand exists and is bound to the Build menu item
+            Assert.That(viewModel!.EditorContent.BuildDocumentationCommand, Is.Not.Null, "BuildDocumentationCommand should be available for menu binding");
+
+            // Test that the command is enabled
+            var canExecute = viewModel.EditorContent.BuildDocumentationCommand.CanExecute(null);
+            Assert.That(canExecute, Is.True, "BuildDocumentationCommand should be enabled");
+        });
     }
 
     [AvaloniaTest]
@@ -149,7 +157,7 @@ public class MenuAndCommandTests : MainWindowTestBase
 
         var markdownCombinationService = Substitute.For<IMarkdownCombinationService>();
         var markdownFileCollectorService = Substitute.For<IMarkdownFileCollectorService>();
-        var markdownRenderingService = Substitute.For<Desktop.Services.IMarkdownRenderingService>();
+        var markdownRenderingService = Substitute.For<IMarkdownRenderingService>();
 
         var stateLogger = NullLoggerFactory.Instance.CreateLogger<EditorStateService>();
         var tabBarLogger = NullLoggerFactory.Instance.CreateLogger<EditorTabBarViewModel>();
@@ -157,12 +165,12 @@ public class MenuAndCommandTests : MainWindowTestBase
 
         var editorStateService = new EditorStateService(stateLogger);
         var editorTabBarViewModel = new EditorTabBarViewModel(tabBarLogger, fileService, editorStateService);
-        var editorContentViewModel = new EditorContentViewModel(contentLogger, editorStateService, options, serviceProvider, markdownCombinationService, markdownFileCollectorService, markdownRenderingService, Substitute.For<Desktop.Factories.ISettingsContentViewModelFactory>());
+        var editorContentViewModel = new EditorContentViewModel(contentLogger, editorStateService, options, serviceProvider, markdownCombinationService, markdownFileCollectorService, markdownRenderingService, Substitute.For<Factories.ISettingsContentViewModelFactory>());
 
-        var logTransitionService = Substitute.For<Desktop.Logging.ILogTransitionService>();
-        var hotkeyService = Substitute.For<Desktop.Services.IHotkeyService>();
-        var editorLogger = NullLoggerFactory.Instance.CreateLogger<Desktop.ViewModels.EditorViewModel>();
-        var editorViewModel = new Desktop.ViewModels.EditorViewModel(editorLogger, options, editorTabBarViewModel, editorContentViewModel, hotkeyService);
+        var logTransitionService = Substitute.For<Logging.ILogTransitionService>();
+        var hotkeyService = Substitute.For<IHotkeyService>();
+        var editorLogger = NullLoggerFactory.Instance.CreateLogger<EditorViewModel>();
+        var editorViewModel = new EditorViewModel(editorLogger, options, editorTabBarViewModel, editorContentViewModel, hotkeyService);
         var viewModel = new MainWindowViewModel(vmLogger, options, editorStateService, editorViewModel, logTransitionService, hotkeyService);
 
         Assert.That(viewModel.EditorContent.BuildDocumentationCommand, Is.Not.Null, "BuildDocumentationCommand should exist");
@@ -266,10 +274,10 @@ public class MenuAndCommandTests : MainWindowTestBase
         var viewModel = window.DataContext as MainWindowViewModel;
 
         Assert.That(viewModel, Is.Not.Null, "ViewModel should exist");
-        Assert.That(viewModel!.SaveCommand, Is.Not.Null, "SaveCommand should exist");
+        Assert.That(viewModel.SaveCommand, Is.Not.Null, "SaveCommand should exist");
 
         // Test that the command cannot be executed when no file is active
-        bool canExecute = viewModel.SaveCommand.CanExecute(null);
+        var canExecute = viewModel.SaveCommand.CanExecute(null);
         Assert.That(canExecute, Is.False, "SaveCommand should not be executable when no file is active");
     }
 
@@ -280,18 +288,22 @@ public class MenuAndCommandTests : MainWindowTestBase
         window.Show();
 
         var viewModel = window.DataContext as MainWindowViewModel;
-        Assert.That(viewModel, Is.Not.Null, "ViewModel should exist");
 
         // Find the main menu
         var menu = window.FindControl<Menu>("MainMenu");
-        Assert.That(menu, Is.Not.Null, "Main menu should exist");
 
-        // Test that the SaveCommand exists and works (bound to the Save menu item)
-        Assert.That(viewModel!.SaveCommand, Is.Not.Null, "SaveCommand should be available for menu binding");
+        Assert.Multiple(() =>
+        {
+            Assert.That(viewModel, Is.Not.Null, "ViewModel should exist");
+            Assert.That(menu, Is.Not.Null, "Main menu should exist");
 
-        // Test that the command cannot be executed when no file is active
-        bool canExecute = viewModel.SaveCommand.CanExecute(null);
-        Assert.That(canExecute, Is.False, "SaveCommand should not be executable when no file is active");
+            // Test that the SaveCommand exists and works (bound to the Save menu item)
+            Assert.That(viewModel!.SaveCommand, Is.Not.Null, "SaveCommand should be available for menu binding");
+
+            // Test that the command cannot be executed when no file is active
+            var canExecute = viewModel.SaveCommand.CanExecute(null);
+            Assert.That(canExecute, Is.False, "SaveCommand should not be executable when no file is active");
+        });
     }
 
     [AvaloniaTest]
@@ -301,42 +313,42 @@ public class MenuAndCommandTests : MainWindowTestBase
         var viewModel = window.DataContext as MainWindowViewModel;
 
         Assert.That(viewModel, Is.Not.Null, "ViewModel should exist");
-        Assert.That(viewModel!.SaveCommand, Is.Not.Null, "SaveCommand should exist");
+        Assert.That(viewModel.SaveCommand, Is.Not.Null, "SaveCommand should exist");
 
         // SaveCommand should not be executable when no file is active
-        bool canExecuteWithoutFile = viewModel.SaveCommand.CanExecute(null);
+        var canExecuteWithoutFile = viewModel.SaveCommand.CanExecute(null);
         Assert.That(canExecuteWithoutFile, Is.False, "SaveCommand should not be executable when no file is active");
 
         // Simulate having an open file by directly setting up the editor state
-        var editorTab = new Desktop.Models.EditorTab
+        var editorTab = new EditorTab
         {
             Id = Guid.NewGuid().ToString(),
             Title = "test.txt",
             FilePath = "/tmp/test.txt",
             Content = "Test file content",
             IsModified = false,
-            TabType = Desktop.Models.TabType.File
+            TabType = TabType.File
         };
         var mockTabViewModel = new EditorTabViewModel(editorTab);
         viewModel.EditorTabBar.EditorTabs.Add(mockTabViewModel);
         viewModel.EditorTabBar.SetActiveTab(mockTabViewModel);
 
         // SaveCommand should not be executable when file is open but not modified
-        bool canExecuteUnmodifiedFile = viewModel.SaveCommand.CanExecute(null);
+        var canExecuteUnmodifiedFile = viewModel.SaveCommand.CanExecute(null);
         Assert.That(canExecuteUnmodifiedFile, Is.False, "SaveCommand should not be executable when file is unmodified");
 
         // Modify the file content
         mockTabViewModel.Content = "modified content";
 
         // Now SaveCommand should be executable
-        bool canExecuteModifiedFile = viewModel.SaveCommand.CanExecute(null);
+        var canExecuteModifiedFile = viewModel.SaveCommand.CanExecute(null);
         Assert.That(canExecuteModifiedFile, Is.True, "SaveCommand should be executable when file is modified");
 
         // Simulate save completion by resetting the modified flag
         mockTabViewModel.IsModified = false;
 
         // After saving, SaveCommand should not be executable again (file no longer modified)
-        bool canExecuteAfterSave = viewModel.SaveCommand.CanExecute(null);
+        var canExecuteAfterSave = viewModel.SaveCommand.CanExecute(null);
         Assert.That(canExecuteAfterSave, Is.False, "SaveCommand should not be executable after file is saved");
     }
 
@@ -349,12 +361,15 @@ public class MenuAndCommandTests : MainWindowTestBase
         var window = CreateMainWindow();
         var viewModel = window.DataContext as MainWindowViewModel;
 
-        Assert.That(viewModel, Is.Not.Null, "ViewModel should exist");
-        Assert.That(viewModel!.SaveAllCommand, Is.Not.Null, "SaveAllCommand should exist");
+        Assert.Multiple(() =>
+        {
+            Assert.That(viewModel, Is.Not.Null, "ViewModel should exist");
+            Assert.That(viewModel!.SaveAllCommand, Is.Not.Null, "SaveAllCommand should exist");
 
-        // SaveAllCommand should not be executable when no files are open
-        bool canExecuteWithoutFiles = viewModel.SaveAllCommand.CanExecute(null);
-        Assert.That(canExecuteWithoutFiles, Is.False, "SaveAllCommand should not be executable when no files are open");
+            // SaveAllCommand should not be executable when no files are open
+            var canExecuteWithoutFiles = viewModel.SaveAllCommand.CanExecute(null);
+            Assert.That(canExecuteWithoutFiles, Is.False, "SaveAllCommand should not be executable when no files are open");
+        });
 
         // Create multiple temporary files
         var tempFile1 = Path.GetTempFileName();
@@ -375,7 +390,7 @@ public class MenuAndCommandTests : MainWindowTestBase
             Assert.That(viewModel.EditorTabBar.EditorTabs.Count, Is.EqualTo(3), "Should have 3 tabs open");
 
             // SaveAllCommand should not be executable when files are open but not modified
-            bool canExecuteUnmodified = viewModel.SaveAllCommand.CanExecute(null);
+            var canExecuteUnmodified = viewModel.SaveAllCommand.CanExecute(null);
             Assert.That(canExecuteUnmodified, Is.False, "SaveAllCommand should not be executable when no files are modified");
 
             // Modify some files
@@ -388,12 +403,15 @@ public class MenuAndCommandTests : MainWindowTestBase
             // Leave tab2 unmodified
 
             // Verify modification states
-            Assert.That(tab1.IsModified, Is.True, "Tab1 should be modified");
-            Assert.That(tab2.IsModified, Is.False, "Tab2 should not be modified");
-            Assert.That(tab3.IsModified, Is.True, "Tab3 should be modified");
+            Assert.Multiple(() =>
+            {
+                Assert.That(tab1.IsModified, Is.True, "Tab1 should be modified");
+                Assert.That(tab2.IsModified, Is.False, "Tab2 should not be modified");
+                Assert.That(tab3.IsModified, Is.True, "Tab3 should be modified");
+            });
 
             // SaveAllCommand should now be executable
-            bool canExecuteModified = viewModel.SaveAllCommand.CanExecute(null);
+            var canExecuteModified = viewModel.SaveAllCommand.CanExecute(null);
             Assert.That(canExecuteModified, Is.True, "SaveAllCommand should be executable when some files are modified");
 
             // Execute SaveAll command
@@ -406,13 +424,16 @@ public class MenuAndCommandTests : MainWindowTestBase
             await WaitForConditionAsync(() => !tab1.IsModified && !tab3.IsModified, timeoutMs: 5000, intervalMs: 100);
 
             // Verify all modified files were saved
-            Assert.That(tab1.IsModified, Is.False, "Tab1 should no longer be modified after save all");
-            Assert.That(tab2.IsModified, Is.False, "Tab2 should still not be modified (was not modified)");
-            Assert.That(tab3.IsModified, Is.False, "Tab3 should no longer be modified after save all");
+            Assert.Multiple(() =>
+            {
+                Assert.That(tab1.IsModified, Is.False, "Tab1 should no longer be modified after save all");
+                Assert.That(tab2.IsModified, Is.False, "Tab2 should still not be modified (was not modified)");
+                Assert.That(tab3.IsModified, Is.False, "Tab3 should no longer be modified after save all");
 
-            // SaveAllCommand should not be executable again (no modified files)
-            bool canExecuteAfterSave = viewModel.SaveAllCommand.CanExecute(null);
-            Assert.That(canExecuteAfterSave, Is.False, "SaveAllCommand should not be executable after all files are saved");
+                // SaveAllCommand should not be executable again (no modified files)
+                var canExecuteAfterSave = viewModel.SaveAllCommand.CanExecute(null);
+                Assert.That(canExecuteAfterSave, Is.False, "SaveAllCommand should not be executable after all files are saved");
+            });
 
             // Verify that WriteFileContentAsync was called for modified files only
             await _fileService.Received(1).WriteFileContentAsync(tempFile1, "modified content1");
@@ -434,17 +455,21 @@ public class MenuAndCommandTests : MainWindowTestBase
         window.Show();
 
         var viewModel = window.DataContext as MainWindowViewModel;
-        Assert.That(viewModel, Is.Not.Null, "ViewModel should exist");
 
         // Find the main menu
         var menu = window.FindControl<Menu>("MainMenu");
-        Assert.That(menu, Is.Not.Null, "Main menu should exist");
 
-        // Test that the SaveAllCommand exists and is properly bound
-        Assert.That(viewModel!.SaveAllCommand, Is.Not.Null, "SaveAllCommand should be available for menu binding");
+        Assert.Multiple(() =>
+        {
+            Assert.That(viewModel, Is.Not.Null, "ViewModel should exist");
+            Assert.That(menu, Is.Not.Null, "Main menu should exist");
 
-        // Test that the command cannot be executed when no files are modified
-        bool canExecute = viewModel.SaveAllCommand.CanExecute(null);
-        Assert.That(canExecute, Is.False, "SaveAllCommand should not be executable when no files are modified");
+            // Test that the SaveAllCommand exists and is properly bound
+            Assert.That(viewModel!.SaveAllCommand, Is.Not.Null, "SaveAllCommand should be available for menu binding");
+
+            // Test that the command cannot be executed when no files are modified
+            var canExecute = viewModel.SaveAllCommand.CanExecute(null);
+            Assert.That(canExecute, Is.False, "SaveAllCommand should not be executable when no files are modified");
+        });
     }
 }

--- a/test/Desktop.UITests/MenuAndCommandTests.cs
+++ b/test/Desktop.UITests/MenuAndCommandTests.cs
@@ -135,9 +135,10 @@ public class MenuAndCommandTests : MainWindowTestBase
         var mockFileCollector = Substitute.For<IMarkdownFileCollectorService>();
         var mockCombination = Substitute.For<IMarkdownCombinationService>();
         var mockFileWriter = Substitute.For<IMarkdownDocumentFileWriterService>();
+        var mockDialogFileService = Substitute.For<IFileService>();
         var mockLogger = NullLoggerFactory.Instance.CreateLogger<BuildConfirmationDialogViewModel>();
         
-        var mockDialogViewModel = new BuildConfirmationDialogViewModel(options, mockFileCollector, mockCombination, mockFileWriter, mockLogger);
+        var mockDialogViewModel = new BuildConfirmationDialogViewModel(options, mockFileCollector, mockCombination, mockFileWriter, mockDialogFileService, mockLogger);
         serviceProvider.GetService(typeof(BuildConfirmationDialogViewModel)).Returns(mockDialogViewModel);
         
         fileService.GetFileStructureAsync().Returns(Task.FromResult<FileSystemItem?>(CreateSimpleTestStructure()));

--- a/test/Desktop.UITests/MenuAndCommandTests.cs
+++ b/test/Desktop.UITests/MenuAndCommandTests.cs
@@ -21,17 +21,17 @@ public class MenuAndCommandTests : MainWindowTestBase
     {
         var window = CreateMainWindow();
         var viewModel = window.DataContext as MainWindowViewModel;
-        
+
         Assert.That(viewModel, Is.Not.Null, "ViewModel should exist");
         Assert.That(viewModel!.ExitCommand, Is.Not.Null, "ExitCommand should exist");
-        
+
         // Track if exit was requested
         bool exitRequested = false;
         viewModel.ExitRequested += (sender, e) => exitRequested = true;
-        
+
         // Execute the exit command
         viewModel.ExitCommand.Execute(null);
-        
+
         Assert.That(exitRequested, Is.True, "ExitRequested event should be triggered when ExitCommand is executed");
     }
 
@@ -40,16 +40,16 @@ public class MenuAndCommandTests : MainWindowTestBase
     {
         var window = CreateMainWindow();
         window.Show();
-        
+
         var viewModel = window.DataContext as MainWindowViewModel;
         Assert.That(viewModel, Is.Not.Null, "ViewModel should exist");
-        
+
         // Verify window is initially open
         Assert.That(window.IsVisible, Is.True, "Window should be visible initially");
-        
+
         // Trigger exit through the command (this will invoke the exit event)
         viewModel!.ExitCommand.Execute(null);
-        
+
         // The window should be closed after the exit command
         // Note: In headless mode, Close() might not change IsVisible immediately,
         // but the OnExitRequested method should have been called
@@ -72,18 +72,18 @@ public class MenuAndCommandTests : MainWindowTestBase
 
         // Test that the ExitCommand exists and works (bound to the Exit menu item)
         Assert.That(viewModel!.ExitCommand, Is.Not.Null, "ExitCommand should be available for menu binding");
-        
+
         // Test that the command can be executed
         bool canExecute = viewModel.ExitCommand.CanExecute(null);
         Assert.That(canExecute, Is.True, "ExitCommand should be executable");
-        
+
         // Track if exit was requested
         bool exitRequested = false;
         viewModel.ExitRequested += (sender, e) => exitRequested = true;
-        
+
         // Execute the command (simulating menu click)
         viewModel.ExitCommand.Execute(null);
-        
+
         Assert.That(exitRequested, Is.True, "Exit should be requested when command is executed");
     }
 
@@ -92,10 +92,10 @@ public class MenuAndCommandTests : MainWindowTestBase
     {
         var window = CreateMainWindow();
         var viewModel = window.DataContext as MainWindowViewModel;
-        
+
         Assert.That(viewModel, Is.Not.Null, "ViewModel should exist");
         Assert.That(viewModel!.EditorContent.BuildDocumentationCommand, Is.Not.Null, "BuildDocumentationCommand should exist");
-        
+
         // Test that the command exists and is enabled
         bool canExecute = viewModel.EditorContent.BuildDocumentationCommand.CanExecute(null);
         Assert.That(canExecute, Is.True, "BuildDocumentationCommand should be enabled");
@@ -117,7 +117,7 @@ public class MenuAndCommandTests : MainWindowTestBase
 
         // Test that the BuildDocumentationCommand exists and is bound to the Build menu item
         Assert.That(viewModel!.EditorContent.BuildDocumentationCommand, Is.Not.Null, "BuildDocumentationCommand should be available for menu binding");
-        
+
         // Test that the command is enabled
         bool canExecute = viewModel.EditorContent.BuildDocumentationCommand.CanExecute(null);
         Assert.That(canExecute, Is.True, "BuildDocumentationCommand should be enabled");
@@ -130,49 +130,50 @@ public class MenuAndCommandTests : MainWindowTestBase
         var options = Options.Create(new ApplicationOptions());
         var fileService = Substitute.For<IFileService>();
         var serviceProvider = Substitute.For<IServiceProvider>();
-        
+
         // Setup mock services for BuildConfirmationDialogViewModel
         var mockFileCollector = Substitute.For<IMarkdownFileCollectorService>();
         var mockCombination = Substitute.For<IMarkdownCombinationService>();
         var mockFileWriter = Substitute.For<IMarkdownDocumentFileWriterService>();
         var mockDialogFileService = Substitute.For<IFileService>();
         var mockLogger = NullLoggerFactory.Instance.CreateLogger<BuildConfirmationDialogViewModel>();
-        
+
         var mockDialogViewModel = new BuildConfirmationDialogViewModel(options, mockFileCollector, mockCombination, mockFileWriter, mockDialogFileService, mockLogger);
+        Assert.That(mockDialogViewModel.CleanOld, Is.False, "Default CleanOld should be false");
         serviceProvider.GetService(typeof(BuildConfirmationDialogViewModel)).Returns(mockDialogViewModel);
-        
+
         fileService.GetFileStructureAsync().Returns(Task.FromResult<FileSystemItem?>(CreateSimpleTestStructure()));
         fileService.GetFileStructureAsync(Arg.Any<string>()).Returns(Task.FromResult<FileSystemItem?>(CreateSimpleTestStructure()));
         fileService.IsValidFolder(Arg.Any<string>()).Returns(true);
         fileService.ReadFileContentAsync(Arg.Any<string>()).Returns("Mock file content");
-        
+
         var markdownCombinationService = Substitute.For<IMarkdownCombinationService>();
         var markdownFileCollectorService = Substitute.For<IMarkdownFileCollectorService>();
         var markdownRenderingService = Substitute.For<Desktop.Services.IMarkdownRenderingService>();
-        
+
         var stateLogger = NullLoggerFactory.Instance.CreateLogger<EditorStateService>();
         var tabBarLogger = NullLoggerFactory.Instance.CreateLogger<EditorTabBarViewModel>();
         var contentLogger = NullLoggerFactory.Instance.CreateLogger<EditorContentViewModel>();
-        
+
         var editorStateService = new EditorStateService(stateLogger);
         var editorTabBarViewModel = new EditorTabBarViewModel(tabBarLogger, fileService, editorStateService);
         var editorContentViewModel = new EditorContentViewModel(contentLogger, editorStateService, options, serviceProvider, markdownCombinationService, markdownFileCollectorService, markdownRenderingService, Substitute.For<Desktop.Factories.ISettingsContentViewModelFactory>());
-        
+
         var logTransitionService = Substitute.For<Desktop.Logging.ILogTransitionService>();
         var hotkeyService = Substitute.For<Desktop.Services.IHotkeyService>();
         var editorLogger = NullLoggerFactory.Instance.CreateLogger<Desktop.ViewModels.EditorViewModel>();
         var editorViewModel = new Desktop.ViewModels.EditorViewModel(editorLogger, options, editorTabBarViewModel, editorContentViewModel, hotkeyService);
         var viewModel = new MainWindowViewModel(vmLogger, options, editorStateService, editorViewModel, logTransitionService, hotkeyService);
-        
+
         Assert.That(viewModel.EditorContent.BuildDocumentationCommand, Is.Not.Null, "BuildDocumentationCommand should exist");
-        
+
         // Track if dialog event was triggered
         BuildConfirmationDialogViewModel? dialogViewModel = null;
         viewModel.ShowBuildConfirmationDialog += (sender, e) => dialogViewModel = e;
-        
+
         // Execute the build command
         viewModel.EditorContent.BuildDocumentationCommand.Execute(null);
-        
+
         Assert.Multiple(() =>
         {
             Assert.That(dialogViewModel, Is.Not.Null, "ShowBuildConfirmationDialog event should be triggered");
@@ -186,7 +187,7 @@ public class MenuAndCommandTests : MainWindowTestBase
     {
         var window = CreateMainWindow();
         var viewModel = window.DataContext as MainWindowViewModel;
-        
+
         Assert.That(viewModel, Is.Not.Null, "ViewModel should exist");
         Assert.Multiple(() =>
         {
@@ -249,7 +250,7 @@ public class MenuAndCommandTests : MainWindowTestBase
             // Verify that services were called
             _markdownFileCollectorService.Received(1).CollectAllMarkdownFilesAsync(Arg.Any<string>());
             _markdownCombinationService.Received(1).Validate(Arg.Any<IEnumerable<MarkdownDocument>>(), Arg.Any<IEnumerable<MarkdownDocument>>());
-            
+
             // Verify that error panel is shown with validation results
             Assert.That(viewModel.IsBottomPanelVisible, Is.True, "Bottom panel should be visible for errors");
             Assert.That(viewModel.ActiveBottomTab, Is.Not.Null, "Active bottom tab should exist");
@@ -263,10 +264,10 @@ public class MenuAndCommandTests : MainWindowTestBase
     {
         var window = CreateMainWindow();
         var viewModel = window.DataContext as MainWindowViewModel;
-        
+
         Assert.That(viewModel, Is.Not.Null, "ViewModel should exist");
         Assert.That(viewModel!.SaveCommand, Is.Not.Null, "SaveCommand should exist");
-        
+
         // Test that the command cannot be executed when no file is active
         bool canExecute = viewModel.SaveCommand.CanExecute(null);
         Assert.That(canExecute, Is.False, "SaveCommand should not be executable when no file is active");
@@ -284,10 +285,10 @@ public class MenuAndCommandTests : MainWindowTestBase
         // Find the main menu
         var menu = window.FindControl<Menu>("MainMenu");
         Assert.That(menu, Is.Not.Null, "Main menu should exist");
-        
+
         // Test that the SaveCommand exists and works (bound to the Save menu item)
         Assert.That(viewModel!.SaveCommand, Is.Not.Null, "SaveCommand should be available for menu binding");
-        
+
         // Test that the command cannot be executed when no file is active
         bool canExecute = viewModel.SaveCommand.CanExecute(null);
         Assert.That(canExecute, Is.False, "SaveCommand should not be executable when no file is active");
@@ -298,7 +299,7 @@ public class MenuAndCommandTests : MainWindowTestBase
     {
         var window = CreateMainWindow();
         var viewModel = window.DataContext as MainWindowViewModel;
-        
+
         Assert.That(viewModel, Is.Not.Null, "ViewModel should exist");
         Assert.That(viewModel!.SaveCommand, Is.Not.Null, "SaveCommand should exist");
 
@@ -344,10 +345,10 @@ public class MenuAndCommandTests : MainWindowTestBase
     {
         // Set up the file service to return success on write operations
         _fileService.WriteFileContentAsync(Arg.Any<string>(), Arg.Any<string>()).Returns(true);
-        
+
         var window = CreateMainWindow();
         var viewModel = window.DataContext as MainWindowViewModel;
-        
+
         Assert.That(viewModel, Is.Not.Null, "ViewModel should exist");
         Assert.That(viewModel!.SaveAllCommand, Is.Not.Null, "SaveAllCommand should exist");
 
@@ -359,7 +360,7 @@ public class MenuAndCommandTests : MainWindowTestBase
         var tempFile1 = Path.GetTempFileName();
         var tempFile2 = Path.GetTempFileName();
         var tempFile3 = Path.GetTempFileName();
-        
+
         try
         {
             await File.WriteAllTextAsync(tempFile1, "content1");
@@ -438,10 +439,10 @@ public class MenuAndCommandTests : MainWindowTestBase
         // Find the main menu
         var menu = window.FindControl<Menu>("MainMenu");
         Assert.That(menu, Is.Not.Null, "Main menu should exist");
-        
+
         // Test that the SaveAllCommand exists and is properly bound
         Assert.That(viewModel!.SaveAllCommand, Is.Not.Null, "SaveAllCommand should be available for menu binding");
-        
+
         // Test that the command cannot be executed when no files are modified
         bool canExecute = viewModel.SaveAllCommand.CanExecute(null);
         Assert.That(canExecute, Is.False, "SaveAllCommand should not be executable when no files are modified");

--- a/test/Desktop.UITests/ViewModels/BuildConfirmationDialogViewModelTests.cs
+++ b/test/Desktop.UITests/ViewModels/BuildConfirmationDialogViewModelTests.cs
@@ -38,7 +38,7 @@ public class BuildConfirmationDialogViewModelTests
         return new BuildConfirmationDialogViewModel(optionsToUse, _mockFileCollector, _mockCombination, _mockFileWriter, _mockFileService, _mockLogger);
     }
 
-    private static async Task WaitForConditionAsync(System.Func<bool> condition, int timeoutMs = 2000, int intervalMs = 10)
+    private static async Task WaitForConditionAsync(Func<bool> condition, int timeoutMs = 2000, int intervalMs = 10)
     {
         var maxWait = timeoutMs / intervalMs;
         var waitCount = 0;
@@ -52,20 +52,20 @@ public class BuildConfirmationDialogViewModelTests
     [AvaloniaTest]
     public void BuildConfirmationDialog_Should_Show_Combined_Project_And_Output_Path()
     {
-        var customOptions = new ApplicationOptions 
-        { 
+        var customOptions = new ApplicationOptions
+        {
             DefaultProjectFolder = "/test/project",
-            DefaultOutputFolder = "test-output" 
+            DefaultOutputFolder = "test-output"
         };
-        
+
         var dialogViewModel = CreateDialogViewModel(customOptions);
-        
+
         Assert.Multiple(() =>
         {
             Assert.That(dialogViewModel.OutputLocation, Is.Not.Null.And.Not.Empty, "Output location should be set");
             Assert.That(dialogViewModel.OutputLocation, Is.EqualTo("/test/project/test-output"), "Should combine project folder and output folder");
-            Assert.That(dialogViewModel.OutputLocation, Does.StartWith("/test/project"), "Should start with project folder");
-            Assert.That(dialogViewModel.OutputLocation, Does.EndWith("test-output"), "Should end with output folder");
+            Assert.That(dialogViewModel.OutputLocation.Replace('\\', '/'), Does.StartWith("/test/project"), "Should start with project folder");
+            Assert.That(dialogViewModel.OutputLocation.Replace('\\', '/'), Does.EndWith("test-output"), "Should end with output folder");
         });
     }
 
@@ -73,7 +73,7 @@ public class BuildConfirmationDialogViewModelTests
     public void BuildConfirmationDialog_Should_Have_Cancel_And_Compile_Commands()
     {
         var dialogViewModel = CreateDialogViewModel();
-        
+
         Assert.Multiple(() =>
         {
             Assert.That(dialogViewModel.CancelCommand, Is.Not.Null, "Cancel command should exist");
@@ -87,14 +87,14 @@ public class BuildConfirmationDialogViewModelTests
     public void BuildConfirmationDialog_Should_Trigger_DialogClosed_Event_On_Cancel()
     {
         var dialogViewModel = CreateDialogViewModel();
-        
+
         // Track if dialog closed event was triggered
         bool dialogClosed = false;
         dialogViewModel.DialogClosed += (sender, e) => dialogClosed = true;
-        
+
         // Execute the cancel command
         dialogViewModel.CancelCommand.Execute(null);
-        
+
         Assert.That(dialogClosed, Is.True, "DialogClosed event should be triggered when Cancel command is executed");
     }
 
@@ -124,7 +124,7 @@ public class BuildConfirmationDialogViewModelTests
                 Content = "# Template 2"
             }
         };
-        
+
         var sourceFiles = new[]
         {
             new MarkdownDocument
@@ -168,7 +168,7 @@ public class BuildConfirmationDialogViewModelTests
 
         // Act
         dialogViewModel.SaveCommand.Execute(null);
-        
+
         // Wait for async build to complete
         await WaitForConditionAsync(() => !dialogViewModel.IsBuildInProgress, 1000);
 
@@ -184,6 +184,7 @@ public class BuildConfirmationDialogViewModelTests
             _mockCombination.Received(1).Validate(Arg.Any<IEnumerable<MarkdownDocument>>(), Arg.Any<IEnumerable<MarkdownDocument>>());
             _mockCombination.Received(1).BuildDocumentation(templateFiles, sourceFiles);
             _mockFileWriter.Received(1).WriteDocumentsToFolderAsync(processedDocuments, "/test/project/output");
+            _mockFileService.DidNotReceive().DeleteFolderContentsAsync(Arg.Any<string>());
         });
     }
 
@@ -206,7 +207,7 @@ public class BuildConfirmationDialogViewModelTests
 
         // Act
         dialogViewModel.SaveCommand.Execute(null);
-        
+
         // Wait for async build to complete
         await WaitForConditionAsync(() => !dialogViewModel.IsBuildInProgress, 1000);
 
@@ -252,6 +253,113 @@ public class BuildConfirmationDialogViewModelTests
             Assert.That(dialogViewModel.IsBuildInProgress, Is.False, "Build should not be in progress initially");
             Assert.That(dialogViewModel.CanBuild, Is.True, "Should be able to build when not in progress");
             Assert.That(dialogViewModel.SaveCommand.CanExecute(null), Is.True, "Compile command should be enabled when build is not in progress");
+        });
+    }
+
+    [AvaloniaTest]
+    public async Task BuildConfirmationDialog_Should_Clean_Output_Before_Writing_When_CleanOld_Enabled()
+    {
+        var customOptions = new ApplicationOptions
+        {
+            DefaultProjectFolder = "/test/project",
+            DefaultOutputFolder = "output"
+        };
+
+        var templateFiles = new[]
+        {
+            new MarkdownDocument { FileName = "t.mdext", FilePath = "/t.mdext", Content = "# T <insert s.mdsrc>" }
+        };
+        var sourceFiles = new[]
+        {
+            new MarkdownDocument { FileName = "s.mdsrc", FilePath = "/s.mdsrc", Content = "S" }
+        };
+        var processedDocuments = new[]
+        {
+            new MarkdownDocument { FileName = "t.md", FilePath = "/t.md", Content = "# T\nS" }
+        };
+
+        _mockFileCollector.CollectAllMarkdownFilesAsync("/test/project").Returns((templateFiles, sourceFiles));
+        _mockCombination.Validate(Arg.Any<IEnumerable<MarkdownDocument>>(), Arg.Any<IEnumerable<MarkdownDocument>>())
+            .Returns(new ValidationResult());
+        _mockCombination.BuildDocumentation(templateFiles, sourceFiles).Returns(processedDocuments);
+        _mockFileService.DeleteFolderContentsAsync("/test/project/output").Returns(true);
+        _mockFileWriter.WriteDocumentsToFolderAsync(processedDocuments, "/test/project/output").Returns(Task.CompletedTask);
+
+        var viewModel = CreateDialogViewModel(customOptions);
+        viewModel.CleanOld = true;
+
+        viewModel.SaveCommand.Execute(null);
+        await WaitForConditionAsync(() => !viewModel.IsBuildInProgress, 3000);
+
+        Assert.Multiple(() =>
+        {
+            _mockFileService.Received(1).DeleteFolderContentsAsync("/test/project/output");
+            _mockFileWriter.Received(1).WriteDocumentsToFolderAsync(processedDocuments, "/test/project/output");
+        });
+    }
+
+    [AvaloniaTest]
+    public async Task BuildConfirmationDialog_Should_Not_Clean_When_CleanOld_Disabled()
+    {
+        var customOptions = new ApplicationOptions
+        {
+            DefaultProjectFolder = "/test/project",
+            DefaultOutputFolder = "output"
+        };
+
+        var templateFiles = new[] { new MarkdownDocument { FileName = "t.mdext", FilePath = "/t.mdext", Content = "# T" } };
+        var sourceFiles = new[] { new MarkdownDocument { FileName = "s.mdsrc", FilePath = "/s.mdsrc", Content = "S" } };
+        var processedDocuments = new[] { new MarkdownDocument { FileName = "t.md", FilePath = "/t.md", Content = "# T" } };
+
+        _mockFileCollector.CollectAllMarkdownFilesAsync("/test/project").Returns((templateFiles, sourceFiles));
+        _mockCombination.Validate(Arg.Any<IEnumerable<MarkdownDocument>>(), Arg.Any<IEnumerable<MarkdownDocument>>())
+            .Returns(new ValidationResult());
+        _mockCombination.BuildDocumentation(templateFiles, sourceFiles).Returns(processedDocuments);
+        _mockFileWriter.WriteDocumentsToFolderAsync(processedDocuments, "/test/project/output").Returns(Task.CompletedTask);
+
+        var viewModel = CreateDialogViewModel(customOptions);
+        viewModel.CleanOld = false; // explicit
+
+        viewModel.SaveCommand.Execute(null);
+        await WaitForConditionAsync(() => !viewModel.IsBuildInProgress, 3000);
+
+        Assert.Multiple(() =>
+        {
+            _mockFileService.DidNotReceive().DeleteFolderContentsAsync(Arg.Any<string>());
+            _mockFileWriter.Received(1).WriteDocumentsToFolderAsync(processedDocuments, "/test/project/output");
+        });
+    }
+
+    [AvaloniaTest]
+    public async Task BuildConfirmationDialog_Should_Proceed_When_Clean_Fails()
+    {
+        var customOptions = new ApplicationOptions
+        {
+            DefaultProjectFolder = "/test/project",
+            DefaultOutputFolder = "output"
+        };
+
+        var templateFiles = new[] { new MarkdownDocument { FileName = "t.mdext", FilePath = "/t.mdext", Content = "# T" } };
+        var sourceFiles = new[] { new MarkdownDocument { FileName = "s.mdsrc", FilePath = "/s.mdsrc", Content = "S" } };
+        var processedDocuments = new[] { new MarkdownDocument { FileName = "t.md", FilePath = "/t.md", Content = "# T" } };
+
+        _mockFileCollector.CollectAllMarkdownFilesAsync("/test/project").Returns((templateFiles, sourceFiles));
+        _mockCombination.Validate(Arg.Any<IEnumerable<MarkdownDocument>>(), Arg.Any<IEnumerable<MarkdownDocument>>())
+            .Returns(new ValidationResult());
+        _mockCombination.BuildDocumentation(templateFiles, sourceFiles).Returns(processedDocuments);
+        _mockFileService.DeleteFolderContentsAsync("/test/project/output").Returns(false); // simulate failure
+        _mockFileWriter.WriteDocumentsToFolderAsync(processedDocuments, "/test/project/output").Returns(Task.CompletedTask);
+
+        var viewModel = CreateDialogViewModel(customOptions);
+        viewModel.CleanOld = true;
+
+        viewModel.SaveCommand.Execute(null);
+        await WaitForConditionAsync(() => !viewModel.IsBuildInProgress, 3000);
+
+        Assert.Multiple(() =>
+        {
+            _mockFileService.Received(1).DeleteFolderContentsAsync("/test/project/output");
+            _mockFileWriter.Received(1).WriteDocumentsToFolderAsync(processedDocuments, "/test/project/output");
         });
     }
 }

--- a/test/Desktop.UITests/ViewModels/BuildConfirmationDialogViewModelTests.cs
+++ b/test/Desktop.UITests/ViewModels/BuildConfirmationDialogViewModelTests.cs
@@ -176,7 +176,6 @@ public class BuildConfirmationDialogViewModelTests
         Assert.Multiple(() =>
         {
             Assert.That(dialogViewModel.CanBuild, Is.True, "Should be able to build again after completion");
-            Assert.That(dialogViewModel.BuildStatus, Does.Contain("completed"), "Should show completion status");
             Assert.That(receivedValidationResult, Is.Not.Null, "ValidationResultsAvailable event should be triggered");
             Assert.That(receivedValidationResult!.IsValid, Is.True, "Validation should pass with no errors");
 
@@ -215,8 +214,6 @@ public class BuildConfirmationDialogViewModelTests
         Assert.Multiple(() =>
         {
             Assert.That(dialogViewModel.CanBuild, Is.True, "Should be able to build again after error");
-            Assert.That(dialogViewModel.BuildStatus, Does.Contain("failed"), "Should show failure status");
-            Assert.That(dialogViewModel.BuildStatus, Does.Contain("Test directory not found"), "Should show error message");
 
             // Verify only file collector was called
             _mockFileCollector.Received(1).CollectAllMarkdownFilesAsync("/test/project");
@@ -242,32 +239,6 @@ public class BuildConfirmationDialogViewModelTests
         });
     }
 
-    [AvaloniaTest]
-    public void BuildConfirmationDialog_Should_Update_Build_Status_Property()
-    {
-        // Arrange
-        var dialogViewModel = CreateDialogViewModel();
-
-        // Track property changes
-        string? capturedStatus = null;
-        dialogViewModel.PropertyChanged += (sender, args) =>
-        {
-            if (args.PropertyName == nameof(dialogViewModel.BuildStatus))
-            {
-                capturedStatus = dialogViewModel.BuildStatus;
-            }
-        };
-
-        // Act
-        dialogViewModel.BuildStatus = "Test status message";
-
-        // Assert
-        Assert.Multiple(() =>
-        {
-            Assert.That(dialogViewModel.BuildStatus, Is.EqualTo("Test status message"), "BuildStatus property should be updated");
-            Assert.That(capturedStatus, Is.EqualTo("Test status message"), "PropertyChanged should be raised for BuildStatus");
-        });
-    }
 
     [AvaloniaTest]
     public void BuildConfirmationDialog_Save_Button_Should_Be_Enabled_When_Build_Not_In_Progress()

--- a/test/Desktop.UITests/ViewModels/BuildConfirmationDialogViewModelTests.cs
+++ b/test/Desktop.UITests/ViewModels/BuildConfirmationDialogViewModelTests.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.Options;
 using Desktop.Configuration;
 using Business.Services;
 using Business.Models;
+using Desktop.Services;
 using NSubstitute;
 using Microsoft.Extensions.Logging.Abstractions;
 
@@ -17,6 +18,7 @@ public class BuildConfirmationDialogViewModelTests
     private IMarkdownFileCollectorService _mockFileCollector = null!;
     private IMarkdownCombinationService _mockCombination = null!;
     private IMarkdownDocumentFileWriterService _mockFileWriter = null!;
+    private IFileService _mockFileService = null!;
     private ILogger<BuildConfirmationDialogViewModel> _mockLogger = null!;
 
     [SetUp]
@@ -26,13 +28,14 @@ public class BuildConfirmationDialogViewModelTests
         _mockFileCollector = Substitute.For<IMarkdownFileCollectorService>();
         _mockCombination = Substitute.For<IMarkdownCombinationService>();
         _mockFileWriter = Substitute.For<IMarkdownDocumentFileWriterService>();
+        _mockFileService = Substitute.For<IFileService>();
         _mockLogger = NullLoggerFactory.Instance.CreateLogger<BuildConfirmationDialogViewModel>();
     }
 
     private BuildConfirmationDialogViewModel CreateDialogViewModel(ApplicationOptions? customOptions = null)
     {
         var optionsToUse = customOptions != null ? Options.Create(customOptions) : _options;
-        return new BuildConfirmationDialogViewModel(optionsToUse, _mockFileCollector, _mockCombination, _mockFileWriter, _mockLogger);
+        return new BuildConfirmationDialogViewModel(optionsToUse, _mockFileCollector, _mockCombination, _mockFileWriter, _mockFileService, _mockLogger);
     }
 
     private static async Task WaitForConditionAsync(System.Func<bool> condition, int timeoutMs = 2000, int intervalMs = 10)

--- a/test/Desktop.UITests/ViewModels/BuildConfirmationDialogViewModelTests.cs
+++ b/test/Desktop.UITests/ViewModels/BuildConfirmationDialogViewModelTests.cs
@@ -306,16 +306,17 @@ public class BuildConfirmationDialogViewModelTests
             DefaultProjectFolder = "/test/project",
             DefaultOutputFolder = "output"
         };
+        var expectedOutput = Path.Combine(customOptions.DefaultProjectFolder, customOptions.DefaultOutputFolder);
 
         var templateFiles = new[] { new MarkdownDocument { FileName = "t.mdext", FilePath = "/t.mdext", Content = "# T" } };
         var sourceFiles = new[] { new MarkdownDocument { FileName = "s.mdsrc", FilePath = "/s.mdsrc", Content = "S" } };
         var processedDocuments = new[] { new MarkdownDocument { FileName = "t.md", FilePath = "/t.md", Content = "# T" } };
 
-        _mockFileCollector.CollectAllMarkdownFilesAsync("/test/project").Returns((templateFiles, sourceFiles));
+        _mockFileCollector.CollectAllMarkdownFilesAsync(customOptions.DefaultProjectFolder).Returns((templateFiles, sourceFiles));
         _mockCombination.Validate(Arg.Any<IEnumerable<MarkdownDocument>>(), Arg.Any<IEnumerable<MarkdownDocument>>())
             .Returns(new ValidationResult());
         _mockCombination.BuildDocumentation(templateFiles, sourceFiles).Returns(processedDocuments);
-        _mockFileWriter.WriteDocumentsToFolderAsync(processedDocuments, "/test/project/output").Returns(Task.CompletedTask);
+        _mockFileWriter.WriteDocumentsToFolderAsync(processedDocuments, expectedOutput).Returns(Task.CompletedTask);
 
         var viewModel = CreateDialogViewModel(customOptions);
         viewModel.CleanOld = false; // explicit
@@ -326,7 +327,7 @@ public class BuildConfirmationDialogViewModelTests
         Assert.Multiple(() =>
         {
             _mockFileService.DidNotReceive().DeleteFolderContentsAsync(Arg.Any<string>());
-            _mockFileWriter.Received(1).WriteDocumentsToFolderAsync(processedDocuments, "/test/project/output");
+            _mockFileWriter.Received(1).WriteDocumentsToFolderAsync(processedDocuments, expectedOutput);
         });
     }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a "Clean old files before build" checkbox in the build confirmation dialog to optionally clear the output folder before generating files.

- **Improvements**
  - Build now optionally performs output-folder cleanup when enabled; cleanup failures are logged but do not block the build.
  - Logging improved for build progress and successful template validation.

- **Tests**
  - New UI/unit tests cover cleaning enabled/disabled behavior, operation sequencing, and graceful handling of cleanup failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->